### PR TITLE
Use TSort to honor middleware before/after constraints regardless of load order

### DIFF
--- a/lib/meddleware/stack.rb
+++ b/lib/meddleware/stack.rb
@@ -1,3 +1,5 @@
+require 'tsort'
+
 module Meddleware
   class Stack
     def initialize(&block)
@@ -6,7 +8,7 @@ module Meddleware
 
     def use(*args, **kwargs, &block)
       entry = create_entry(args, kwargs, block)
-      remove(entry[0])
+      remove(entry[0], clear_constraints: false)
       stack << entry
       self
     end
@@ -14,53 +16,62 @@ module Meddleware
 
     def prepend(*args, **kwargs, &block)
       entry = create_entry(args, kwargs, block)
-      remove(entry[0])
+      remove(entry[0], clear_constraints: false)
       stack.insert(0, entry)
       self
     end
 
     def after(after_klass, *args, **kwargs, &block)
       entry = create_entry(args, kwargs, block)
-      remove(entry[0])
+      remove(entry[0], clear_constraints: true, clear_as_target: false)
 
       i = if after_klass.is_a? Array
-        after_klass.map {|x| index(x) }.compact.max
+        after_klass.map { |x| index(x) }.compact.max
       else
         index(after_klass)
       end
       i ||= count - 1 # last element
 
       stack.insert(i + 1, entry)
+      add_ordering_constraints(after_klass, entry[0], :after)
       self
     end
 
     def before(before_klass, *args, **kwargs, &block)
       entry = create_entry(args, kwargs, block)
-      remove(entry[0])
+      remove(entry[0], clear_constraints: true, clear_as_target: false)
 
       i = if before_klass.is_a? Array
-        before_klass.map {|x| index(x) }.compact.min
+        before_klass.map { |x| index(x) }.compact.min
       else
         index(before_klass)
       end
       i ||= 0 # first element
 
       stack.insert(i, entry)
+      add_ordering_constraints(before_klass, entry[0], :before)
       self
     end
 
     def include?(*klass)
-      klass.all? {|x| index(x) }
+      klass.all? { |x| index(x) }
     end
 
-    def remove(*klass)
+    def remove(*klass, clear_constraints: true, clear_as_target: true)
       stack.reject! { |entry| klass.include?(entry[0]) }
+
+      if clear_constraints
+        constraints.reject! do |source, target|
+          klass.include?(source) || (clear_as_target && klass.include?(target))
+        end
+      end
+
       self
     end
 
     def replace(old_klass, *args, **kwargs, &block)
       entry = create_entry(args, kwargs, block)
-      remove(entry[0])
+      remove(entry[0], clear_constraints: true, clear_as_target: false)
 
       i = index(old_klass)
 
@@ -68,7 +79,13 @@ module Meddleware
         raise RuntimeError, "middleware not present: #{old_klass}"
       end
 
-      stack[i] = entry
+      stack.delete_at(i)
+      constraints.map! do |source, target|
+        source = entry[0] if source == old_klass
+        target = entry[0] if target == old_klass
+        [ source, target ]
+      end
+      stack.insert(i, entry)
       self
     end
 
@@ -79,6 +96,7 @@ module Meddleware
 
     def clear
       stack.clear
+      constraints.clear
     end
 
     def empty?
@@ -125,8 +143,12 @@ module Meddleware
       @stack ||= []
     end
 
+    def constraints
+      @constraints ||= []
+    end
+
     def index(klass)
-      stack.index {|entry| entry[0] == klass }
+      sorted_stack.index { |entry| entry[0] == klass }
     end
 
     def create_entry(args, kwargs, block)
@@ -160,7 +182,7 @@ module Meddleware
 
     def build_chain
       # build the middleware stack
-      stack.map do |klass, args, kwargs, block|
+      sorted_stack.map do |klass, args, kwargs, block|
         if klass.is_a? Class
           klass.new(*args, **kwargs, &block)
         else
@@ -181,6 +203,58 @@ module Meddleware
             end
           end
         end
+      end
+    end
+
+    def sorted_stack
+      entries_by_key = stack.each_with_object({}) { |entry, hash| hash[entry[0]] = entry }
+      keys = entries_by_key.keys
+      deps = keys.each_with_object({}) { |key, hash| hash[key] = [] }
+
+      constraints.each do |before_key, after_key|
+        next unless entries_by_key.key?(before_key) && entries_by_key.key?(after_key)
+
+        deps[after_key] << before_key
+      end
+
+      sorter = Object.new
+      sorter.extend(TSort)
+      sorter.define_singleton_method(:tsort_each_node) { |&blk| keys.each(&blk) }
+      sorter.define_singleton_method(:tsort_each_child) { |node, &blk| deps[node].each(&blk) }
+      sorter.tsort # validates there are no cycles
+
+      dependents = keys.each_with_object({}) { |key, hash| hash[key] = [] }
+      indegree = keys.each_with_object({}) { |key, hash| hash[key] = deps[key].count }
+
+      deps.each do |node, prerequisites|
+        prerequisites.each do |prerequisite|
+          dependents[prerequisite] << node
+        end
+      end
+
+      queue = keys.select { |key| indegree[key].zero? }
+      sorted_keys = []
+
+      until queue.empty?
+        node = queue.shift
+        sorted_keys << node
+
+        dependents[node].each do |dependent|
+          indegree[dependent] -= 1
+          next unless indegree[dependent].zero?
+
+          insert_at = queue.index { |candidate| keys.index(candidate) > keys.index(dependent) } || queue.length
+          queue.insert(insert_at, dependent)
+        end
+      end
+
+      sorted_keys.map { |key| entries_by_key[key] }
+    end
+
+    def add_ordering_constraints(targets, middleware, position)
+      Array(targets).compact.each do |target|
+        pair = position == :before ? [ middleware, target ] : [ target, middleware ]
+        constraints << pair unless constraints.include?(pair)
       end
     end
   end

--- a/spec/stack_spec.rb
+++ b/spec/stack_spec.rb
@@ -196,6 +196,13 @@ describe Meddleware::Stack do
       expect(stack).to eq [ A, C ]
     end
 
+    it 'sorts correctly when dependency target is added later' do
+      subject.after B, C
+      subject.use A
+      subject.use B
+      expect(stack).to eq [ A, B, C ]
+    end
+
     context 'when target is an array' do
       before do
         subject.use A
@@ -252,6 +259,13 @@ describe Meddleware::Stack do
       subject.use A
       subject.before nil, C
       expect(stack).to eq [ C, A ]
+    end
+
+    it 'sorts correctly when dependency target is added later' do
+      subject.before B, C
+      subject.use A
+      subject.use B
+      expect(stack).to eq [ C, A, B ]
     end
 
     context 'when target is an array' do


### PR DESCRIPTION
### Motivation
- Ensure `before`/`after` relationships between middleware are honored even when the referenced target is registered after the dependent middleware. 
- Avoid relying solely on insertion order so middleware ordering is deterministic and respects declared constraints.

### Description
- Add `require 'tsort'` and track ordering constraints separately, recording `before`/`after` pairs via `add_ordering_constraints` when middleware is added. 
- Compute a dependency-aware, stable topological order in `sorted_stack` (validate cycles with `TSort` then perform a stable Kahn-like topo sort) and make `build_chain` and `index` use that order. 
- Update mutation methods (`use`, `prepend`, `remove`, `replace`, `clear`) to preserve and manage constraint metadata (avoid clearing constraints on simple re-add, allow remapping on `replace`, and clear constraints on `clear`). 
- Add regression specs in `spec/stack_spec.rb` to cover `before`/`after` cases where the dependency target is added later.

### Testing
- Ran `bundle exec rspec` and confirmed the full suite passes with `188 examples, 0 failures`.
- The change was iteratively tested by reproducing the failing regression and verifying the fix with the test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea9c5c77608321b3a44a8c8af01d2b)