### PR TITLE
Use TSort for declarative middleware ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,22 @@ end
 See [documentation](https://github.com/dpep/meddleware_rb/wiki/DSL) for full DSL.
 
 
+## Ordering
+
+Middleware can declare ordering constraints via `before:` and `after:`.  The stack is resolved with a topological sort (via Ruby's `TSort`), so the order is correct regardless of when each middleware is added.
+
+```ruby
+MyWidget.middleware do
+  use Logger,    before: Auth
+  use Validator, after:  Auth
+  use Auth
+end
+# => [ Logger, Auth, Validator ]
+```
+
+The convenience methods `before(target, ...)` and `after(target, ...)` are shorthand for the same.
+
+
 ----
 ## Full Example
 ```ruby

--- a/lib/meddleware/stack.rb
+++ b/lib/meddleware/stack.rb
@@ -1,52 +1,36 @@
+require 'tsort'
+
 module Meddleware
   class Stack
+    include TSort
+
+    Entry = Struct.new(:klass, :args, :kwargs, :block, :before, :after)
+
     def initialize(&block)
       instance_eval(&block) if block_given?
     end
 
-    def use(*args, **kwargs, &block)
-      entry = create_entry(args, kwargs, block)
-      remove(entry[0])
+    def use(*args, before: nil, after: nil, **kwargs, &block)
+      entry = create_entry(args, kwargs, block, before: before, after: after)
+      remove(entry.klass)
       stack << entry
       self
     end
     alias append use
 
-    def prepend(*args, **kwargs, &block)
-      entry = create_entry(args, kwargs, block)
-      remove(entry[0])
-      stack.insert(0, entry)
+    def prepend(*args, before: nil, after: nil, **kwargs, &block)
+      entry = create_entry(args, kwargs, block, before: before, after: after)
+      remove(entry.klass)
+      stack.unshift(entry)
       self
     end
 
     def after(after_klass, *args, **kwargs, &block)
-      entry = create_entry(args, kwargs, block)
-      remove(entry[0])
-
-      i = if after_klass.is_a? Array
-        after_klass.map {|x| index(x) }.compact.max
-      else
-        index(after_klass)
-      end
-      i ||= count - 1 # last element
-
-      stack.insert(i + 1, entry)
-      self
+      use(*args, **kwargs, after: after_klass, &block)
     end
 
     def before(before_klass, *args, **kwargs, &block)
-      entry = create_entry(args, kwargs, block)
-      remove(entry[0])
-
-      i = if before_klass.is_a? Array
-        before_klass.map {|x| index(x) }.compact.min
-      else
-        index(before_klass)
-      end
-      i ||= 0 # first element
-
-      stack.insert(i, entry)
-      self
+      use(*args, **kwargs, before: before_klass, &block)
     end
 
     def include?(*klass)
@@ -54,13 +38,13 @@ module Meddleware
     end
 
     def remove(*klass)
-      stack.reject! { |entry| klass.include?(entry[0]) }
+      stack.reject! { |entry| klass.include?(entry.klass) }
       self
     end
 
-    def replace(old_klass, *args, **kwargs, &block)
-      entry = create_entry(args, kwargs, block)
-      remove(entry[0])
+    def replace(old_klass, *args, before: nil, after: nil, **kwargs, &block)
+      entry = create_entry(args, kwargs, block, before: before, after: after)
+      remove(entry.klass)
 
       i = index(old_klass)
 
@@ -126,10 +110,28 @@ module Meddleware
     end
 
     def index(klass)
-      stack.index {|entry| entry[0] == klass }
+      stack.index {|entry| entry.klass == klass }
     end
 
-    def create_entry(args, kwargs, block)
+    # TSort: iterate over all entries
+    def tsort_each_node(&block)
+      stack.each(&block)
+    end
+
+    # TSort: yield entries that must come BEFORE the given entry
+    def tsort_each_child(entry, &block)
+      after_targets = Array(entry.after).compact
+      stack.each do |other|
+        next if other.equal?(entry)
+        other_before = Array(other.before).compact
+
+        if after_targets.include?(other.klass) || other_before.include?(entry.klass)
+          yield other
+        end
+      end
+    end
+
+    def create_entry(args, kwargs, block, before: nil, after: nil)
       klass, *args = args
 
       if [ klass, block ].none?
@@ -152,15 +154,20 @@ module Meddleware
           end
         end
 
-        [ klass, args, kwargs, block ].compact
+        Entry.new(klass, args, kwargs, block, before, after)
       else
-        [ block ]
+        Entry.new(block, nil, nil, nil, before, after)
       end
     end
 
     def build_chain
-      # build the middleware stack
-      stack.map do |klass, args, kwargs, block|
+      # build the middleware stack, resolving dependencies via TSort
+      tsort.map do |entry|
+        klass = entry.klass
+        args = entry.args
+        kwargs = entry.kwargs
+        block = entry.block
+
         if klass.is_a? Class
           klass.new(*args, **kwargs, &block)
         else

--- a/spec/stack_spec.rb
+++ b/spec/stack_spec.rb
@@ -169,11 +169,18 @@ describe Meddleware::Stack do
   describe '#after' do
     it_behaves_like 'a middleware adder method', :after
 
-    it 'adds middleware where specified' do
+    it 'orders middleware after the target' do
       subject.use A
       subject.use B
       subject.after A, C
-      expect(stack).to eq [ A, C, B ]
+      expect(stack).to eq [ A, B, C ]
+    end
+
+    it 'is order independent' do
+      subject.after A, C
+      subject.use B
+      subject.use A
+      expect(stack.index(A)).to be < stack.index(C)
     end
 
     it 'maintans order for duplicates' do
@@ -181,7 +188,7 @@ describe Meddleware::Stack do
       subject.use B
       subject.after A, C
       subject.after A, C
-      expect(stack).to eq [ A, C, B ]
+      expect(stack).to eq [ A, B, C ]
     end
 
     it 'works when target is missing' do
@@ -209,12 +216,12 @@ describe Meddleware::Stack do
 
       it 'ignores missing targets' do
         subject.after [ A, Meddler ], C
-        expect(stack).to eq [ A, C, B ]
+        expect(stack).to eq [ A, B, C ]
       end
 
       it 'handles nil targets' do
         subject.after [ nil, A ], C
-        expect(stack).to eq [ A, C, B ]
+        expect(stack).to eq [ A, B, C ]
       end
 
       it 'handles an empty array' do
@@ -227,11 +234,18 @@ describe Meddleware::Stack do
   describe '#before' do
     it_behaves_like 'a middleware adder method', :before
 
-    it 'adds middleware where specified' do
+    it 'orders middleware before the target' do
       subject.use A
       subject.use B
       subject.before B, C
       expect(stack).to eq [ A, C, B ]
+    end
+
+    it 'is order independent' do
+      subject.before B, C
+      subject.use A
+      subject.use B
+      expect(stack.index(C)).to be < stack.index(B)
     end
 
     it 'maintans order for duplicates' do
@@ -245,13 +259,13 @@ describe Meddleware::Stack do
     it 'works when target is missing' do
       subject.use A
       subject.before B, C
-      expect(stack).to eq [ C, A ]
+      expect(stack).to eq [ A, C ]
     end
 
     it 'works when target is nil' do
       subject.use A
       subject.before nil, C
-      expect(stack).to eq [ C, A ]
+      expect(stack).to eq [ A, C ]
     end
 
     context 'when target is an array' do
@@ -277,7 +291,7 @@ describe Meddleware::Stack do
 
       it 'handles an empty array' do
         subject.before [], C
-        expect(stack).to eq [ C, A, B ]
+        expect(stack).to eq [ A, B, C ]
       end
     end
   end
@@ -449,6 +463,62 @@ describe Meddleware::Stack do
 
       expect(instance).to include A
       expect(instance).to include B
+    end
+  end
+
+  describe 'dependency resolution' do
+    it 'resolves order regardless of load order' do
+      subject.use C, after: B
+      subject.use B, after: A
+      subject.use A
+      expect(stack).to eq [ A, B, C ]
+    end
+
+    it 'accepts before: kwarg on use' do
+      subject.use B
+      subject.use A, before: B
+      expect(stack).to eq [ A, B ]
+    end
+
+    it 'accepts after: kwarg on use' do
+      subject.use A
+      subject.use B, after: A
+      expect(stack).to eq [ A, B ]
+    end
+
+    it 'accepts an array for before:' do
+      subject.use A
+      subject.use B
+      subject.use C, before: [ A, B ]
+      expect(stack).to eq [ C, A, B ]
+    end
+
+    it 'accepts an array for after:' do
+      subject.use A
+      subject.use B
+      subject.use C, after: [ A, B ]
+      expect(stack).to eq [ A, B, C ]
+    end
+
+    it 'supports before: and after: on prepend' do
+      subject.use A
+      subject.use B
+      subject.prepend C, after: A
+      expect(stack).to eq [ A, C, B ]
+    end
+
+    it 'ignores constraints on missing middleware' do
+      subject.use A, after: :missing
+      subject.use B, before: :missing
+      expect(stack).to eq [ A, B ]
+    end
+
+    it 'raises on circular dependencies' do
+      subject.use A, after: B
+      subject.use B, after: A
+      expect {
+        subject.send(:build_chain)
+      }.to raise_error(TSort::Cyclic)
     end
   end
 


### PR DESCRIPTION
## Summary

Middleware can now declare `before:` and `after:` dependencies, and the stack is resolved with a topological sort (via Ruby's `TSort`) at build time — so the resulting order is **independent of the order middleware is added**.

Inspired by [`Rails::Initializable::Collection`](https://github.com/rails/rails/blob/main/railties/lib/rails/initializable.rb).

```ruby
MyWidget.middleware do
  use Logger,    before: Auth
  use Validator, after:  Auth
  use Auth
end
# => [ Logger, Auth, Validator ]
```

`before(target, ...)` and `after(target, ...)` remain as sugar for `use(..., before: target)` / `use(..., after: target)`.

## Behavior changes

The shift from "immediate insertion" to "declarative constraint" alters a few corner cases:

- `use A; use B; after A, C` is now `[A, B, C]` (previously `[A, C, B]`). The constraint is "C comes after A", not "C immediately after A".
- `before B, C` when `B` is missing (or `nil`) now treats the constraint as vacuous and appends `C`, instead of falling back to prepending.
- Circular dependencies raise `TSort::Cyclic` at build time.

## Test plan

- [x] Existing 186 examples updated where semantics differ; all pass
- [x] New `dependency resolution` describe block covering: order-independent resolution, `before:`/`after:` kwargs on `use` and `prepend`, array constraints, missing-target tolerance, and cycle detection
- [x] 196 / 196 examples passing, 100% line coverage

---
_Generated by [Claude Code](https://claude.ai/code/session_01H6vT3rdo2cAt6cmPeg6AHw)_