### PR TITLE
Fix replace when new klass matches old_klass

### DIFF
--- a/lib/meddleware/stack.rb
+++ b/lib/meddleware/stack.rb
@@ -44,7 +44,7 @@ module Meddleware
 
     def replace(old_klass, *args, before: nil, after: nil, **kwargs, &block)
       entry = create_entry(args, kwargs, block, before: before, after: after)
-      remove(entry.klass)
+      remove(entry.klass) unless entry.klass == old_klass
 
       i = index(old_klass)
 

--- a/spec/stack_spec.rb
+++ b/spec/stack_spec.rb
@@ -452,6 +452,11 @@ describe Meddleware::Stack do
         subject.replace(A, nil)
       }.to raise_error(ArgumentError)
     end
+
+    it 'replaces a middleware with itself, updating constraints' do
+      subject.replace(A, A, after: B)
+      expect(stack).to eq [ B, A ]
+    end
   end
 
   describe '.new' do


### PR DESCRIPTION
## Summary

Fix `replace(A, A, ...)` raising `"middleware not present: A"`. The implementation called `remove(entry.klass)` before looking up `old_klass`, which removed the entry it was about to overwrite. Skip the dedupe-remove when the replacement targets itself.

Enables updating an existing middleware's constraints in place:

```ruby
stack.use A
stack.replace A, A, after: B   # previously raised, now works
```

Follow-up to #16.

## Test plan

- [x] New spec: `replaces a middleware with itself, updating constraints`
- [x] Existing replace specs still pass (197/197, 100% line coverage)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H6vT3rdo2cAt6cmPeg6AHw)_