### PR TITLE
Use static, dependabot-parseable forms in gemspec

### DIFF
--- a/meddleware.gemspec
+++ b/meddleware.gemspec
@@ -1,11 +1,10 @@
 require_relative "lib/meddleware/version"
-package = Meddleware
 
 Gem::Specification.new do |s|
-  s.name        = File.basename(__FILE__).split(".")[0]
-  s.version     = package.const_get 'VERSION'
+  s.name        = "meddleware"
+  s.version     = Meddleware::VERSION
   s.authors     = ['Daniel Pepper']
-  s.summary     = package.to_s
+  s.summary     = "Meddleware"
   s.description = 'A middleware framework to make meddling easy.'
   s.homepage    = "https://github.com/dpep/meddleware_rb"
   s.license     = 'MIT'


### PR DESCRIPTION
## Summary

Dependabot's gemspec parser is **static** — it doesn't eval Ruby, it reads the AST and looks for assignments like `s.version = SomeConst::VERSION` or string literals. The dynamic forms in our gemspec defeated that:

```ruby
s.name    = File.basename(__FILE__).split(".")[0]   # dynamic
s.version = package.const_get 'VERSION'              # dynamic
```

When dependabot can't extract the version statically, it falls back to `0.0.1` and writes that into `Gemfile.lock`. CI then fails in frozen mode because the lockfile's `meddleware (0.0.1)` no longer matches the gemspec's actual `0.4.0` — see #13.

This PR switches to the canonical Bundler-scaffold shape:

```ruby
s.name    = "meddleware"
s.version = Meddleware::VERSION
```

`lib/meddleware/version.rb` remains the single source of truth.

## Effect on #13

Once this lands, rebasing #13 onto `main` should produce a `Gemfile.lock` with `meddleware (0.4.0)` and CI will go green. Future dependabot bumps stop hitting this trap.

## Test plan

- [x] `Bundler.load_gemspec("meddleware.gemspec")` returns name `meddleware`, version `0.4.0`
- [x] `bundle install` produces no `Gemfile.lock` diff on `main`
- [x] Full spec suite passes (196/196)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H6vT3rdo2cAt6cmPeg6AHw)_