### PR TITLE
Set gemspec summary to a useful one-liner

### DIFF
--- a/meddleware.gemspec
+++ b/meddleware.gemspec
@@ -5,10 +5,12 @@ Gem::Specification.new do |s|
   s.version     = Meddleware::VERSION
   s.authors     = [ 'Daniel Pepper' ]
   s.summary     = 'A middleware framework to make meddling easy.'
-  s.description = 'Lightweight, Rack-style middleware for any Ruby class. ' \
-                  'Lets callers wrap execution with before/after hooks — ' \
-                  'modifying arguments, intercepting results, or logging — ' \
-                  'without monkey patching. Supports declarative ordering via TSort.'
+  s.description = <<~DESC
+    Lightweight, Rack-style middleware for any Ruby class.
+    Lets callers wrap execution with before/after hooks —
+    modifying arguments, intercepting results, or logging —
+    without monkey patching. Supports declarative ordering via TSort.
+  DESC
   s.homepage    = 'https://github.com/dpep/meddleware_rb'
   s.license     = 'MIT'
   s.files       = `git ls-files * ':!:spec'`.split("\n")

--- a/meddleware.gemspec
+++ b/meddleware.gemspec
@@ -1,12 +1,15 @@
-require_relative "lib/meddleware/version"
+require_relative 'lib/meddleware/version'
 
 Gem::Specification.new do |s|
-  s.name        = "meddleware"
+  s.name        = 'meddleware'
   s.version     = Meddleware::VERSION
-  s.authors     = ['Daniel Pepper']
+  s.authors     = [ 'Daniel Pepper' ]
   s.summary     = 'A middleware framework to make meddling easy.'
-  s.description = s.summary
-  s.homepage    = "https://github.com/dpep/meddleware_rb"
+  s.description = 'Lightweight, Rack-style middleware for any Ruby class. ' \
+                  'Lets callers wrap execution with before/after hooks — ' \
+                  'modifying arguments, intercepting results, or logging — ' \
+                  'without monkey patching. Supports declarative ordering via TSort.'
+  s.homepage    = 'https://github.com/dpep/meddleware_rb'
   s.license     = 'MIT'
   s.files       = `git ls-files * ':!:spec'`.split("\n")
 

--- a/meddleware.gemspec
+++ b/meddleware.gemspec
@@ -4,8 +4,8 @@ Gem::Specification.new do |s|
   s.name        = "meddleware"
   s.version     = Meddleware::VERSION
   s.authors     = ['Daniel Pepper']
-  s.summary     = "Meddleware"
-  s.description = 'A middleware framework to make meddling easy.'
+  s.summary     = 'A middleware framework to make meddling easy.'
+  s.description = s.summary
   s.homepage    = "https://github.com/dpep/meddleware_rb"
   s.license     = 'MIT'
   s.files       = `git ls-files * ':!:spec'`.split("\n")


### PR DESCRIPTION
## Summary

`s.summary` was just the gem name (`"Meddleware"`) — that's what shows in `gem list`, `gem search`, and as the subtitle on rubygems.org/gems/meddleware. It carries no information beyond the name itself.

Use the same one-line description that already lives in `s.description`. RubyGems requires `summary` to be set, so dropping it isn't an option; collapsing to a single source-of-truth one-liner is the next best thing.

## Test plan

- [x] `Bundler.load_gemspec` reports `summary` and `description` = "A middleware framework to make meddling easy."

---
_Generated by [Claude Code](https://claude.ai/code/session_01H6vT3rdo2cAt6cmPeg6AHw)_