### PR TITLE
improve thread-safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,20 @@ combined.call(request) { ... }
 ```
 
 
+## Thread safety
+
+Meddleware follows the standard middleware pattern: configure once, then invoke concurrently.  `Stack#call` uses only local state, so multiple threads may execute the same chain in parallel.  Mutation methods (`use`, `prepend`, `remove`, `replace`, `clear`) are *not* safe to run concurrently with `call` or with each other, so keep configuration on a single thread at boot.
+
+Once configuration is done, `Stack#freeze` locks the chain: it freezes the underlying entry list so any later mutation raises `FrozenError`, while `call` continues to work.
+
+```ruby
+MyWidget.middleware do
+  use Auth
+  use Logger
+end.freeze
+```
+
+
 ----
 ## Full Example
 ```ruby

--- a/lib/meddleware.rb
+++ b/lib/meddleware.rb
@@ -11,6 +11,8 @@ module Meddleware
   private
 
   def self.extended(base)
+    base.instance_variable_set(:@middleware, Meddleware::Stack.new)
+
     unless base.instance_methods.include?(:middleware)
       base.class_eval do
         def middleware

--- a/lib/meddleware/stack.rb
+++ b/lib/meddleware/stack.rb
@@ -7,7 +7,13 @@ module Meddleware
     Entry = Struct.new(:klass, :args, :kwargs, :block, :before, :after)
 
     def initialize(&block)
+      @stack = []
       instance_eval(&block) if block_given?
+    end
+
+    def freeze
+      @stack.freeze
+      super
     end
 
     def use(*args, before: nil, after: nil, **kwargs, &block)
@@ -119,7 +125,7 @@ module Meddleware
     protected
 
     def stack
-      @stack ||= []
+      @stack
     end
 
     def index(klass)

--- a/spec/meddleware_spec.rb
+++ b/spec/meddleware_spec.rb
@@ -17,6 +17,10 @@ describe Meddleware do
       expect(klass.middleware).to be(klass.middleware)
     end
 
+    it 'eagerly initializes the middleware stack' do
+      expect(klass.instance_variable_get(:@middleware)).to be_a Meddleware::Stack
+    end
+
     it 'enables DSL' do
       klass.middleware do
         use Meddler

--- a/spec/stack_spec.rb
+++ b/spec/stack_spec.rb
@@ -601,6 +601,48 @@ describe Meddleware::Stack do
     end
   end
 
+  describe '#freeze' do
+    before do
+      subject.use A
+      subject.freeze
+    end
+
+    it 'freezes the stack' do
+      expect(subject).to be_frozen
+    end
+
+    it 'freezes the underlying entry list' do
+      expect(subject.send(:stack)).to be_frozen
+    end
+
+    it 'blocks further mutation' do
+      expect { subject.use B }.to raise_error(FrozenError)
+      expect { subject.prepend B }.to raise_error(FrozenError)
+      expect { subject.remove A }.to raise_error(FrozenError)
+      expect { subject.replace A, B }.to raise_error(FrozenError)
+      expect { subject.clear }.to raise_error(FrozenError)
+    end
+
+    it 'still executes the chain' do
+      m = Meddler.new
+      stack = Meddleware::Stack.new
+      stack.use m
+      stack.freeze
+
+      expect(m).to receive(:call).and_yield
+      expect {|b| stack.call(&b) }.to yield_control
+    end
+
+    it 'does not prevent concatenation' do
+      other = Meddleware::Stack.new
+      other.use B
+      result = subject + other
+
+      expect(result).not_to be_frozen
+      expect(result.send(:build_chain).map(&:class)).to eq [ A, B ]
+    end
+  end
+
   describe '#index' do
     before do
       subject.use A


### PR DESCRIPTION
## Summary
Small, low-risk thread-safety pass — the "configure at boot, call concurrently" contract that most middleware libraries take.

- **Eager init.** `Stack@stack` is set in the constructor, and `Meddleware.extended` eagerly initializes the class-level `@middleware`. This closes the `||=` first-call race between concurrent readers that never mutated the stack.
- **`Stack#freeze`.** Overrides `Object#freeze` to also freeze the underlying entry list, so any post-config mutation (`use` / `prepend` / `remove` / `replace` / `clear`) raises `FrozenError` while `call` continues to work. Gives apps a way to guarantee the chain is locked once boot finishes.
- **README.** Adds a short "Thread safety" section explaining the contract.

Deliberately *not* in this PR: per-instance mutation locks, memoized `build_chain`, per-instance `@middleware` eager init on `include` (each instance would need it, and there's no clean hook). Those are bigger changes with tradeoffs — happy to open follow-ups if you want them.

## Test plan
- [x] `bundle exec rspec` — 212 examples, 0 failures (6 new), 100% line coverage
- [x] Frozen stack raises `FrozenError` on `use` / `prepend` / `remove` / `replace` / `clear`
- [x] Frozen stack still executes correctly under `call`
- [x] Frozen stack can still be the LHS of `+` (result is not frozen)
- [x] `extend Meddleware` sets `@middleware` immediately (verified via `instance_variable_get`)
- [x] Existing subclass behavior preserved: a child class still gets its own stack via lazy init on the child

---
_Generated by [Claude Code](https://claude.ai/code/session_011rcoScQ3Zuvj2GMf4QAaV2)_